### PR TITLE
feature: add cpp implementation of ALU for testing

### DIFF
--- a/tb/cpu/alu_golden/golden_alu.cpp
+++ b/tb/cpu/alu_golden/golden_alu.cpp
@@ -1,0 +1,37 @@
+// golden_alu.cpp — tiny C "golden" reference model for hdl/cpu/components/rv_alu.sv
+//
+// Mirrors the ALU op encodings defined in hdl/chiplevel/rv_alu_types.sv.
+// The testbench calls this via DPI-C and compares its result against the
+// actual RTL output for the same inputs (self-checking scoreboard).
+
+#include <cstdint>
+#include <cstdio>
+
+extern "C" int golden_alu(int in1_i, int in2_i, int op) {
+    uint32_t a = static_cast<uint32_t>(in1_i);
+    uint32_t b = static_cast<uint32_t>(in2_i);
+    int32_t  sa = static_cast<int32_t>(a);
+    int32_t  sb = static_cast<int32_t>(b);
+    uint32_t shamt = b & 0x3F;  // matches RTL's in2[5:0]
+    uint32_t result = 0;
+
+    switch (op) {
+        case 0:  result = a & b; break;                                   // ALU_AND
+        case 1:  result = a | b; break;                                   // ALU_OR
+        case 2:  result = a + b; break;                                   // ALU_ADD
+        case 3:  result = (shamt >= 32) ? 0 : (a << shamt); break;        // ALU_SLL
+        case 4:  result = (shamt >= 32) ? 0 : (a >> shamt); break;        // ALU_SRL
+        case 5:  result = (shamt >= 32)                                   // ALU_SRA
+                              ? static_cast<uint32_t>(sa >> 31)
+                              : static_cast<uint32_t>(sa >> shamt);
+                 break;
+        case 6:  result = a - b; break;                                   // ALU_SUB
+        case 7:  result = (sa < sb) ? 1 : 0; break;                       // ALU_SLT
+        case 8:  result = a ^ b; break;                                   // ALU_XOR
+        case 10: result = (a < b) ? 1 : 0; break;                         // ALU_SLTU
+        case 12: result = ~(a | b); break;                                // ALU_NOR
+        default: result = 0; break;
+    }
+
+    return static_cast<int>(result);
+}

--- a/tb/cpu/alu_golden/test_alu_golden.f
+++ b/tb/cpu/alu_golden/test_alu_golden.f
@@ -1,0 +1,3 @@
+// test_alu_golden.f — filelist for the ALU golden-model self-checking test
+${CHIPLEVEL_DIR}/rv_alu_types.sv
+${CPU_DIR}/components/rv_alu.sv

--- a/tb/cpu/alu_golden/test_alu_golden.sv
+++ b/tb/cpu/alu_golden/test_alu_golden.sv
@@ -1,0 +1,67 @@
+// test_alu_golden.sv — barebones golden-reference-model self-checking test
+//
+// Instantiates the real rv_alu RTL (hdl/cpu/components/rv_alu.sv), drives it
+// with random operands/ops, and compares its output each cycle against a
+// C "golden" model (golden_alu.cpp) called via DPI-C.
+//
+// Run with:
+//   scripts/run test_alu_golden -- tb/cpu/alu_golden/golden_alu.cpp
+
+module test_alu_golden;
+
+  import rv_alu_types::*;
+
+  // DPI-C import: C reference model for the ALU
+  import "DPI-C" function int golden_alu(input int in1, input int in2, input int op);
+
+  logic [31:0] in1, in2, out;
+  alu_op_e     op;
+  logic        equal_flag, less_flag, greater_eq_flag, ult_flag, uge_flag;
+
+  // DUT: the real ALU RTL
+  rv_alu dut (
+      .in1(in1),
+      .in2(in2),
+      .alu_op(op),
+      .out(out),
+      .equal_flag(equal_flag),
+      .less_flag(less_flag),
+      .greater_eq_flag(greater_eq_flag),
+      .unsigned_less_flag(ult_flag),
+      .unsigned_greater_eq_flag(uge_flag)
+  );
+
+  // All ALU ops exercised by this test
+  alu_op_e ops[11] = '{
+      ALU_AND, ALU_OR, ALU_ADD, ALU_SLL, ALU_SRL,
+      ALU_SRA, ALU_SUB, ALU_SLT, ALU_XOR, ALU_SLTU, ALU_NOR
+  };
+
+  localparam int NUM_VECTORS = 50;
+  int errors = 0;
+  int expected;
+
+  initial begin
+    for (int i = 0; i < NUM_VECTORS; i++) begin
+      in1 = $urandom;
+      in2 = $urandom;
+      op  = ops[$urandom_range(0, $size(ops) - 1)];
+
+      #1;  // let the (combinational) RTL settle
+
+      expected = golden_alu(in1, in2, int'(op));
+
+      if (out !== expected[31:0]) begin
+        $display("FAIL: op=%s in1=%0h in2=%0h  rtl=%0h golden=%0h",
+                  op.name(), in1, in2, out, expected);
+        errors++;
+      end
+    end
+
+    if (errors == 0) $display("PASS: all %0d vectors matched the golden model", NUM_VECTORS);
+    else $display("FAIL: %0d/%0d vectors mismatched", errors, NUM_VECTORS);
+
+    $finish;
+  end
+
+endmodule


### PR DESCRIPTION
Failures look like: 

<img width="680" height="114" alt="Screenshot 2026-07-21 113739" src="https://github.com/user-attachments/assets/1b5ce992-e383-4271-abd2-a460cb8cfe16" />

Passes look like:
<img width="653" height="105" alt="Screenshot 2026-07-21 113748" src="https://github.com/user-attachments/assets/afda9b1b-f22a-46b7-8f7a-6dfd33768442" />

this cpp implmentation allows us to catch all mismatches between the standard ALU implementation in CPP vs our RTL.

can be extended to catch mismatches in other blocks too.

run with `run test_alu_golden -- tb/cpu/alu_golden/golden_alu.cpp`